### PR TITLE
added output file option

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -2,7 +2,12 @@
 
 "use strict";
 
+var fs = require('fs');
+
 var suite = 'jshint';
+
+var wrStream;
+var outputFile;
 
 function encode(s) {
   var pairs = {
@@ -39,10 +44,16 @@ function failure_details(failures) {
   return msg.join("\n");
 }
 
-exports.reporter = function (results) {
+exports.reporter = function (results, data, opts) {
 
   var out = [];
   var files = {};
+
+  opts = opts || {};
+  opts.outputFile = opts.outputFile || null;
+
+  if (opts.outputFile && !outputFile)
+    outputFile = opts.outputFile;
 
   results.forEach(function (result) {
     result.file = result.file.replace(/^\.\//, '');
@@ -69,9 +80,14 @@ exports.reporter = function (results) {
   }
 
   out.push("</testsuite>");
-  out = out.join("\n") + "\n";
 
-  process.stdout.write(out);
+  if (outputFile) {
+    fs.writeFileSync(outputFile, out.join('\n'));
+  } else {
+    out = out.join("\n") + "\n";
+    process.stdout.write(out);
+  }
+
   return out;
 
 };

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
 var assert = require('assert');
 var path = require('path');
+var fs = require('fs');
+var outputFile = __dirname + '/test.xml';
 var tests = [];
 var mock1 = []; // 0 error
 var mock2 = [{  // 1 error
@@ -124,6 +126,23 @@ tests.push(function() {
   var results = formatter.reporter(mock3);
   process.stdout.write = oldWrite;
   if (results.replace(strip, '') !== expected3.replace(strip, '')) {
+    throw new Error('Unexpected results');
+  }
+});
+
+// test for output file
+tests.push(function() {
+  var formatter = require('./reporter.js');
+  var results = formatter.reporter(mock3, null, { outputFile: outputFile });
+  var success = false;
+  var content;
+  if (fs.existsSync(outputFile)) {
+    content = fs.readFileSync(outputFile, "utf8");
+    if (content.replace(strip, '') === expected3.replace(strip, ''))
+      success = true;
+    fs.unlinkSync(outputFile);
+  }
+  if (!success) {
     throw new Error('Unexpected results');
   }
 });


### PR DESCRIPTION
Hi xjamundx, The gulp jshint implementation doesn't provide a convenient way to pipe output to a file, I added some functionality to your project to allow for an "outputFile" option. Let me know what you think or if you'd like something different.
