### PR TITLE
Changing the reporter.js to use the quantity of files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jshint-junit-reporter",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A JSHint reporter for jUnit.",
   "license": "MIT",
   "main": "index.js",

--- a/reporter.js
+++ b/reporter.js
@@ -10,84 +10,90 @@ var wrStream;
 var outputFile;
 
 function encode(s) {
-  var pairs = {
-    "&": "&amp;",
-    '"': "&quot;",
-    "'": "&apos;",
-    "<": "&lt;",
-    ">": "&gt;"
-  };
-  for (var r in pairs) {
-    if (typeof(s) !== "undefined") {
-      s = s.replace(new RegExp(r, "g"), pairs[r]);
-    }
-  }
-  return s || "";
+	var pairs = {
+		"&": "&amp;",
+		'"': "&quot;",
+		"'": "&apos;",
+		"<": "&lt;",
+		">": "&gt;"
+	};
+	for (var r in pairs) {
+		if (typeof(s) !== "undefined") {
+			s = s.replace(new RegExp(r, "g"), pairs[r]);
+		}
+	}
+	return s || "";
 }
 
 function failure_message(failures) {
-  var count = failures.length;
-  if (count === 1) {
-    return "1 JSHINT Failure";
-  } else {
-    return count + " JSHint Failures";
-  }
+	var count = failures.length;
+	if (count === 1) {
+		return "1 JSHINT Failure";
+	} else {
+		return count + " JSHint Failures";
+	}
 }
 
 function failure_details(failures) {
-  var msg = [];
-  var item;
-  for (var i = 0; i < failures.length; i++) {
-    item = failures[i];
-    msg.push(i+1 + ". line " + item.line + ", char " + item.character + ": " + encode(item.reason));
-  }
-  return msg.join("\n");
+	var msg = [];
+	var item;
+	for (var i = 0; i < failures.length; i++) {
+		item = failures[i];
+		msg.push(i+1 + ". line " + item.line + ", char " + item.character + ": " + encode(item.reason));
+	}
+	return msg.join("\n");
 }
 
 exports.reporter = function (results, data, opts) {
 
-  var out = [];
-  var files = {};
+	var out = [];
+	var files = {};
 
-  opts = opts || {};
-  opts.outputFile = opts.outputFile || null;
+	opts = opts || {};
+	opts.outputFile = opts.outputFile || null;
 
-  if (opts.outputFile && !outputFile)
-    outputFile = opts.outputFile;
+	if (opts.outputFile && !outputFile)
+		outputFile = opts.outputFile;
 
-  results.forEach(function (result) {
-    result.file = result.file.replace(/^\.\//, '');
-    if (!files[result.file]) {
-      files[result.file] = [];
-    }
-    files[result.file].push(result.error);
-  });
+	results.forEach(function (result) {
+		result.file = result.file.replace(/^\.\//, '');
+		if (!files[result.file]) {
+			files[result.file] = [];
+		}
+		files[result.file].push(result.error);
+	});
 
-  out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-  out.push("<testsuite name=\"" + suite + "\" tests=\"" + (data.length || 0) + "\" failures=\"" + results.length + "\" errors=\"0\">");
+	out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+	out.push("<testsuite name=\"" + suite + "\" tests=\"" + (data.length || 0) + "\" failures=\"" + results.length + "\" errors=\"0\">");
 
-  // we need at least 1 empty test
-  if (!results.length) {
-    out.push("\t<testcase name=\"" + suite + "\" />");
-  }
+	// we need at least 1 empty test
+	if (!results.length) {
+		out.push("\t<testcase name=\"" + suite + "\" />");
+	}
 
-  for (var file in files) {
-    out.push("\t<testcase name=\"" + file + "\">");
-    out.push("\t\t<failure message=\"" + failure_message(files[file]) + "\">");
-    out.push(failure_details(files[file]));
-    out.push("\t\t</failure>");
-    out.push("\t</testcase>");
-  }
+	for (var i = 0; i < data.length; i++) {
+		var file = data[i].file;
+		//has an error
+		if (files[file]) {
+			out.push("\t<testcase name=\"" + file + "\">");
+			out.push("\t\t<failure message=\"" + failure_message(files[file]) + "\">");
+			out.push(failure_details(files[file]));
+			out.push("\t\t</failure>");
+			out.push("\t</testcase>");
+		} else {
+			out.push("\t<testcase name=\"" + file + "\" />");
+		}
+	}
 
-  out.push("</testsuite>");
+	out.push("</testsuite>");
 
-  if (outputFile) {
-    fs.writeFileSync(outputFile, out.join('\n'));
-  } else {
-    out = out.join("\n") + "\n";
-    process.stdout.write(out);
-  }
+	if (outputFile) {
+		fs.writeFileSync(outputFile, out.join('\n'));
+	} else {
+		out = out.join("\n") + "\n";
+		process.stdout.write(out);
+	}
 
-  return out;
+	return out;
 
 };

--- a/reporter.js
+++ b/reporter.js
@@ -64,7 +64,7 @@ exports.reporter = function (results, data, opts) {
   });
 
   out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-  out.push("<testsuite name=\"" + suite + "\" tests=\"" + (Object.keys(files).length === 0 ? 1 : Object.keys(files).length) + "\" failures=\"" + results.length + "\" errors=\"0\">");
+  out.push("<testsuite name=\"" + suite + "\" tests=\"" + (data.length || 0) + "\" failures=\"" + results.length + "\" errors=\"0\">");
 
   // we need at least 1 empty test
   if (!results.length) {


### PR DESCRIPTION
Currently the report (when all are passed) will just show up as 1 test rather than the quantity of tests which are done, this change will always report how many files have been tested regardless of any errors.