### PR TITLE
Fix failure detection, jsxhint bug, and improve style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jshint-junit-reporter",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A JSHint reporter for jUnit.",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jshint-junit-reporter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A JSHint reporter for jUnit.",
   "license": "MIT",
   "main": "index.js",

--- a/reporter.js
+++ b/reporter.js
@@ -77,7 +77,7 @@ exports.reporter = function (results, data, opts) {
 	}
 
 	results.forEach(function (result) {
-		result.file = result.file.replace(/^\.\//, '');
+		result.file = result.file.replace(/^[\.\/\\]*/, '');
 
 		if (!files[result.file]) {
 			files[result.file] = [];

--- a/reporter.js
+++ b/reporter.js
@@ -59,8 +59,10 @@ function getMatchingResultFileName(file, failureList) {
 			return failureFile;
 		}
 
-		return file;
 	}
+
+
+	return file;
 
 }
 

--- a/reporter.js
+++ b/reporter.js
@@ -17,16 +17,19 @@ function encode(s) {
 		"<": "&lt;",
 		">": "&gt;"
 	};
+
 	for (var r in pairs) {
 		if (typeof(s) !== "undefined") {
 			s = s.replace(new RegExp(r, "g"), pairs[r]);
 		}
 	}
+
 	return s || "";
 }
 
 function failure_message(failures) {
 	var count = failures.length;
+
 	if (count === 1) {
 		return "1 JSHINT Failure";
 	} else {
@@ -37,45 +40,41 @@ function failure_message(failures) {
 function failure_details(failures) {
 	var msg = [];
 	var item;
+
 	for (var i = 0; i < failures.length; i++) {
 		item = failures[i];
 		msg.push(i+1 + ". line " + item.line + ", char " + item.character + ": " + encode(item.reason));
 	}
+
 	return msg.join("\n");
 }
 
-//jsxhint stores the files in a tmp dir
-//this means the data list and the results array don't match
-//to remedy we can loop through list and remove the non-matching string
+// jsxhint stores the files in a tmp dir
+// this means the data list and the results array don't match
+// to remedy we can loop through list and remove the non-matching string
 function getMatchingResultFileName(file, failureList) {
-
 	for (var failureFile in failureList) {
-
-		//if the end of the file provided identically matches that in the failures list
-		//the files will be the same just 1 has a bunch of tmpdir rubbish at the front.
-		//return the failureFile link
-
 		if (file.indexOf(failureFile) === (file.length-failureFile.length)) {
+			// if the end of the file provided identically matches that in the failures list
+			// the files will be the same just 1 has a bunch of tmpdir rubbish at the front.
+			// return the failureFile link
 			return failureFile;
 		}
-
 	}
 
-
 	return file;
-
 }
 
 exports.reporter = function (results, data, opts) {
-
 	var out = [];
 	var files = {};
 
 	opts = opts || {};
 	opts.outputFile = opts.outputFile || null;
 
-	if (opts.outputFile && !outputFile)
+	if (opts.outputFile && !outputFile) {
 		outputFile = opts.outputFile;
+	}
 
 	results.forEach(function (result) {
 		result.file = result.file.replace(/^\.\//, '');
@@ -83,6 +82,7 @@ exports.reporter = function (results, data, opts) {
 		if (!files[result.file]) {
 			files[result.file] = [];
 		}
+
 		files[result.file].push(result.error);
 	});
 
@@ -97,18 +97,15 @@ exports.reporter = function (results, data, opts) {
 	for (var i = 0; i < data.length; i++) {
 		var fileName = data[i].file;
 
-		//so this works with jsxhint as well
-		//jsxhint puts the files into a cache dir
-		//but doesn't change the location of the results to match
-		//so we have to work around it
+		// jsxhint puts the files into a cache dir but doesn't change the location of the results to match
 		if (fileName.indexOf('/jsxhint/') > -1) {
 			fileName = getMatchingResultFileName(fileName, files);
 		}
 
-		//jshint seems to shove itself at the start in some versions
+		// jshint seems to shove itself at the start in some versions
 		if (fileName !== 'jshint') {
-			//has an error
 			if (files[fileName]) {
+				// has an error
 				out.push("\t<testcase name=\"" + fileName + "\">");
 				out.push("\t\t<failure message=\"" + failure_message(files[fileName]) + "\">");
 				out.push(failure_details(files[fileName]));
@@ -130,5 +127,4 @@ exports.reporter = function (results, data, opts) {
 	}
 
 	return out;
-
 };


### PR DESCRIPTION
Failures for the current file are output if the file's name exists in the `files` object. This object is populated with filenames by  stripping dot directories from the front of the path given by jshint. Unfortunately, only two characters were being stripped: './'. This is insufficient on Windows and for files outside of the reporterOutput(?) directory. Thus, the regex was updated to strip any number of '.', '\', or '/' characters from the start of the file's path.

The version was updated to reflect this bug fix.